### PR TITLE
Getting UG3 384-ch passive headstages to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Builds/*/*
 # 3. OS-specific files
 
 .DS_Store
+
+# 4. Jetbrains metadata
+.idea

--- a/Source/Basestations/Basestation_v3.cpp
+++ b/Source/Basestations/Basestation_v3.cpp
@@ -148,9 +148,11 @@ bool Basestation_v3::open()
 						headstage = nullptr;
 					}
 				}
-				else if (hsPartNumber == "NPNH_HS_30") // 128-ch analog headstage
+				else if (hsPartNumber == "NPNH_HS_30") // 128-ch analog headstage OR 384-ch analog UG3 headstage
 				{
-					LOGC("      Found 128-ch analog headstage on port: ", port);
+                    // NOTE: we dynamically determine if this is a UG3 probe or a "normal" NHP passive probe based on
+                    // a whitelist of hard-coded serial numbers. See details in the implementation below.
+					LOGC("      Found 128-ch or 384-ch analog headstage on port: ", port);
 					headstage = new Headstage_Analog128(this, port);
 				}
 				else if (hsPartNumber == "NPM_HS_30" || hsPartNumber == "NPM_HS_01") // 2.0 headstage, 2 docks

--- a/Source/Formats/IMRO.h
+++ b/Source/Formats/IMRO.h
@@ -11,9 +11,10 @@ public:
 	{
         file.create();
 
-        if (settings.probeType == ProbeType::NP1 || 
+        if (settings.probeType == ProbeType::NP1 ||
+            settings.probeType == ProbeType::UG3 ||
             settings.probeType == ProbeType::NHP10 ||
-            settings.probeType == ProbeType::NHP25 || 
+            settings.probeType == ProbeType::NHP25 ||
             settings.probeType == ProbeType::NHP45 ||
             settings.probeType == ProbeType::UHD1)
         {
@@ -142,7 +143,7 @@ public:
 
     static void parseValues(Array<int> values, ProbeType probeType, ProbeSettings& settings)
     {
-        if (probeType == ProbeType::NP1 || probeType == ProbeType::NHP10)
+        if (probeType == ProbeType::NP1 || probeType == ProbeType::NHP10 || probeType == ProbeType::UG3)
         {
             // 0 = 1.0 probe
            // channel ID

--- a/Source/Headstages/Headstage_Analog128.cpp
+++ b/Source/Headstages/Headstage_Analog128.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Headstage_Analog128.h"
 #include "../Probes/Neuropixels_NHP_Passive.h"
+#include "../Probes/Neuropixels_UG3_Passive.h"
 
 #define MAXLEN 50
 
@@ -78,7 +79,24 @@ Headstage_Analog128::Headstage_Analog128(Basestation* bs_, int port) : Headstage
 
 	flexCables.add(new Flex1_NHP(this));
 
-	probes.add(new Neuropixels_NHP_Passive(basestation, this, flexCables[0]));
+    const std::vector<uint64_t> UG3_HEADSTAGE_SERIAL_NUMBERS = {
+            // TODO: fill these in
+            0,
+    };
+
+    bool isUG3 = false;
+    for (uint64_t snUG3 : UG3_HEADSTAGE_SERIAL_NUMBERS) {
+        if (info.serial_number == snUG3) {
+            isUG3 = true;
+            break;
+        }
+    }
+
+    if (isUG3) {
+        probes.add(new Neuropixels_UG3_Passive(basestation, this, flexCables[0], info.serial_number));
+    } else {
+        probes.add(new Neuropixels_NHP_Passive(basestation, this, flexCables[0]));
+    }
 	probes[0]->setStatus(SourceStatus::CONNECTING);
 }
 

--- a/Source/Headstages/Headstage_Analog128.h
+++ b/Source/Headstages/Headstage_Analog128.h
@@ -29,6 +29,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../NeuropixComponents.h"
 
 
+/**
+ * NOTE: this is EITHER a standard passive 128-ch headstage used for NHP passive probes, OR a 384-ch passive headstage
+ * used for the UG3 project.
+ */
 class Headstage_Analog128 : public Headstage
 {
 public:

--- a/Source/NeuropixComponents.h
+++ b/Source/NeuropixComponents.h
@@ -75,6 +75,7 @@ enum class BasestationType {
 enum class ProbeType {
 	NONE = 1,
 	NP1,
+    UG3,
 	NHP10,
 	NHP25,
 	NHP45,

--- a/Source/Probes/Geometry.cpp
+++ b/Source/Probes/Geometry.cpp
@@ -40,7 +40,10 @@ bool Geometry::forPartNumber(String PN,
 		NHP2(45, em, pm);
 
 	else if (PN.equalsIgnoreCase("NP1200") || PN.equalsIgnoreCase("NP1210"))
-		NHP1(em, pm);
+        NHP1(em, pm);
+
+    else if (PN.equalsIgnoreCase("UG3100"))
+        UG3(em, pm);
 
 	else if (PN.equalsIgnoreCase("PRB2_1_2_0640_0") || PN.equalsIgnoreCase("PRB2_1_4_0480_1") || PN.equalsIgnoreCase("NP2000"))
 		NP2(1, em, pm);
@@ -526,6 +529,66 @@ void Geometry::NHP1(Array<ElectrodeMetadata>& electrodeMetadata,
 	}
 }
 
+
+void Geometry::UG3(Array<ElectrodeMetadata>& electrodeMetadata,
+                    ProbeMetadata& probeMetadata)
+{
+
+    probeMetadata.type = ProbeType::UG3;
+    probeMetadata.name = "Neuropixels UG3";
+
+    Path path;
+    path.startNewSubPath(27, 31);
+    path.lineTo(27, 514);
+    path.lineTo(27 + 10, 514);
+    path.lineTo(27 + 10, 31);
+    path.closeSubPath();
+
+    probeMetadata.shank_count = 1;
+    probeMetadata.electrodes_per_shank = 384;
+    probeMetadata.rows_per_shank = 384;
+    probeMetadata.columns_per_shank = 1;
+    probeMetadata.shankOutline = path;
+    probeMetadata.num_adcs = 32;
+
+    probeMetadata.availableBanks =
+            { Bank::A
+            };
+
+    Array<int> channel_map;
+    for (int i = 0; i < 384; i++) {
+        // NB: seems to be 1-indexed in others
+        channel_map.add(i + 1);
+    }
+
+    Array<float> xpositions = { 27.0f, 59.0f, 11.0f, 43.0f };
+
+    for (int i = 0; i < 384; i++)
+    {
+        ElectrodeMetadata metadata;
+
+        metadata.global_index = i;
+
+        metadata.shank = 0;
+        metadata.shank_local_index = i;
+
+        // Arbitrary, set to "NP-like" dimensions
+        metadata.xpos = 35;
+        metadata.ypos = i * 10.0f;
+        metadata.site_width = 12;
+
+        metadata.column_index = 0;
+        metadata.row_index = metadata.shank_local_index;
+
+        metadata.bank = Bank::A;
+        metadata.channel = channel_map[i];
+        metadata.status = ElectrodeStatus::CONNECTED;
+
+        metadata.isSelected = false;
+
+        electrodeMetadata.add(metadata);
+    }
+}
 
 
 void Geometry::NHP2(int length, 

--- a/Source/Probes/Geometry.h
+++ b/Source/Probes/Geometry.h
@@ -73,6 +73,11 @@ public:
 	static void UHD(bool switchable, Array<ElectrodeMetadata>& em,
 		ProbeMetadata& pm);
 
+    /**
+     * Neuropixels UG3; see Neuropixels_UG3_Passive for details
+     */
+    static void UG3(Array<ElectrodeMetadata>& em, ProbeMetadata& pm);
+
 	/** Neuropixels Opto
 	*/
 	static void OPTO(Array<ElectrodeMetadata>& em, 

--- a/Source/Probes/Neuropixels_UG3_Passive.cpp
+++ b/Source/Probes/Neuropixels_UG3_Passive.cpp
@@ -1,0 +1,472 @@
+/*
+------------------------------------------------------------------
+
+This file is part of the Open Ephys GUI
+Copyright (C) 2018 Allen Institute for Brain Science and Open Ephys
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "Neuropixels_UG3_Passive.h"
+#include "Geometry.h"
+
+void Neuropixels_UG3_Passive::getInfo() {
+    // Loaded in constructor already
+}
+
+Neuropixels_UG3_Passive::Neuropixels_UG3_Passive(Basestation* bs, Headstage* hs, Flex* fl, uint64_t sn) : Probe(bs, hs, fl, 0)
+{
+    info.serial_number = sn;
+    // Matches logic found in Geometry.cpp and IMRO logic elsewhere
+    info.part_number = "UG3100";
+
+	setStatus(SourceStatus::DISCONNECTED);
+
+	customName.probeSpecific = String(info.serial_number);
+
+	Geometry::forPartNumber(info.part_number, electrodeMetadata, probeMetadata);
+
+	name = probeMetadata.name;
+	type = probeMetadata.type;
+
+	settings.probe = this;
+
+	settings.availableBanks = probeMetadata.availableBanks;
+
+	settings.apGainIndex = 3;
+	settings.lfpGainIndex = 2;
+	settings.referenceIndex = 0;
+	settings.apFilterState = true;
+
+	channel_count = 384;
+	lfp_sample_rate = 2500.0f;
+	ap_sample_rate = 30000.0f;
+	
+	for (int i = 0; i < channel_count; i++)
+    {
+        settings.selectedBank.add(Bank::A);
+        settings.selectedChannel.add(i);
+        settings.selectedShank.add(0);
+		settings.selectedElectrode.add(i);
+    }
+
+	settings.availableApGains.add(50.0f);
+	settings.availableApGains.add(125.0f);
+	settings.availableApGains.add(250.0f);
+	settings.availableApGains.add(500.0f);
+	settings.availableApGains.add(1000.0f);
+	settings.availableApGains.add(1500.0f);
+	settings.availableApGains.add(2000.0f);
+	settings.availableApGains.add(3000.0f);
+
+	settings.availableLfpGains.add(50.0f);
+	settings.availableLfpGains.add(125.0f);
+	settings.availableLfpGains.add(250.0f);
+	settings.availableLfpGains.add(500.0f);
+	settings.availableLfpGains.add(1000.0f);
+	settings.availableLfpGains.add(1500.0f);
+	settings.availableLfpGains.add(2000.0f);
+	settings.availableLfpGains.add(3000.0f);
+
+    // Only external reference available
+	settings.availableReferences.add("REF_ELEC");
+
+	open();
+
+}
+
+bool Neuropixels_UG3_Passive::open()
+{
+
+	errorCode = Neuropixels::openProbe(basestation->slot, headstage->port, dock);
+	LOGD("[UG3 PROBE] openProbe: slot: ", basestation->slot, " port: ", headstage->port, " dock: ", dock, " errorCode: ", errorCode);
+	
+	ap_timestamp = 0;
+	lfp_timestamp = 0;
+	eventCode = 0;
+
+	apView = new ActivityView(384, 3000);
+	lfpView = new ActivityView(384, 250);
+
+	return errorCode == Neuropixels::SUCCESS;
+
+}
+
+bool Neuropixels_UG3_Passive::close()
+{
+	errorCode = Neuropixels::closeProbe(basestation->slot, headstage->port, dock);
+	LOGD("closeProbe: slot: ", basestation->slot, " port: ", headstage->port, " dock: ", dock, " errorCode: ", errorCode);
+	
+	return errorCode == Neuropixels::SUCCESS;
+}
+
+void Neuropixels_UG3_Passive::initialize(bool signalChainIsLoading)
+{
+
+	errorCode = Neuropixels::init(basestation->slot, headstage->port, dock);
+	LOGD("init: slot: ", basestation->slot, " port: ", headstage->port, " dock: ", dock, " errorCode: ", errorCode);
+	
+	errorCode = Neuropixels::setOPMODE(basestation->slot, headstage->port, dock, Neuropixels::RECORDING);
+	LOGD("setOPMODE: slot: ", basestation->slot, " port: ", headstage->port, " dock: ", dock, " errorCode: ", errorCode);
+
+	errorCode = Neuropixels::setHSLed(basestation->slot, headstage->port, false);
+	LOGD("setHSLed: slot: ", basestation->slot, " port: ", headstage->port, " dock: ", dock, " errorCode: ", errorCode);
+
+}
+
+
+void Neuropixels_UG3_Passive::calibrate()
+{
+	File baseDirectory = File::getSpecialLocation(File::currentExecutableFile).getParentDirectory();
+	File calibrationDirectory = baseDirectory.getChildFile("CalibrationInfo");
+	File probeDirectory = calibrationDirectory.getChildFile(String(info.serial_number));
+
+	if (!probeDirectory.exists())
+	{
+		// check alternate location
+		baseDirectory = CoreServices::getSavedStateDirectory();
+		calibrationDirectory = baseDirectory.getChildFile("CalibrationInfo");
+		probeDirectory = calibrationDirectory.getChildFile(String(info.serial_number));
+	}
+
+	if (!probeDirectory.exists())
+	{
+
+		if (!calibrationWarningShown)
+		{
+
+			// show popup notification window
+			String message = "Missing calibration files for probe serial number " + String(info.serial_number);
+			message += ". ADC and Gain calibration files must be located in 'CalibrationInfo\\<serial_number>' folder in the directory where the Open Ephys GUI was launched.";
+			message += "The GUI will proceed without calibration.";
+			message += "The plugin must be deleted and re-inserted once calibration files have been added";
+
+			AlertWindow::showMessageBox(AlertWindow::AlertIconType::WarningIcon, "Calibration files missing", message, "OK");
+
+			calibrationWarningShown = true;
+
+		}
+
+		return;
+	}
+
+	String adcFile = probeDirectory.getChildFile(String(info.serial_number) + "_ADCCalibration.csv").getFullPathName();
+	String gainFile = probeDirectory.getChildFile(String(info.serial_number) + "_gainCalValues.csv").getFullPathName();
+	LOGD("ADC file: ", adcFile);
+
+	errorCode = Neuropixels::setADCCalibration(basestation->slot, headstage->port, adcFile.toRawUTF8());
+
+	if (errorCode == 0) { LOGD("Successful ADC calibration."); }
+	else { LOGD("Unsuccessful ADC calibration, failed with error code: ", errorCode); }
+
+	LOGD("Gain file: ", gainFile);
+
+	errorCode = Neuropixels::setGainCalibration(basestation->slot, headstage->port, dock, gainFile.toRawUTF8());
+
+	if (errorCode == 0) { LOGD("Successful gain calibration."); }
+	else { LOGD("Unsuccessful gain calibration, failed with error code: ", errorCode); }
+
+    // NB: NHP passive does this, but v3 probe doesn't?
+	errorCode = Neuropixels::writeProbeConfiguration(basestation->slot, headstage->port, dock, false);
+
+	if (!errorCode == Neuropixels::SUCCESS) { LOGD("Failed to write probe config w/ error code: ", errorCode); }
+	else { LOGD("Successfully wrote probe config "); }
+	
+}
+
+void Neuropixels_UG3_Passive::selectElectrodes()
+{
+	// not available, all active, all the time
+}
+
+void Neuropixels_UG3_Passive::setApFilterState()
+{
+	for (int channel = 0; channel < 384; channel++)
+		Neuropixels::setAPCornerFrequency(basestation->slot,
+			headstage->port,
+			dock,
+			channel,
+			!settings.apFilterState); // true if disabled
+}
+
+void Neuropixels_UG3_Passive::setAllGains()
+{
+
+	for (int channel = 0; channel < 384; channel++)
+	{
+		Neuropixels::setGain(basestation->slot, headstage->port, dock,
+			channel,
+			settings.apGainIndex,
+			settings.lfpGainIndex);
+	}
+
+}
+
+
+void Neuropixels_UG3_Passive::setAllReferences()
+{
+
+	Neuropixels::channelreference_t refId = Neuropixels::EXT_REF;
+	int refElectrodeBank = 0;
+
+	for (int channel = 0; channel < 384; channel++)
+		Neuropixels::setReference(basestation->slot, headstage->port, dock, channel, 0, refId, refElectrodeBank);
+
+
+}
+
+void Neuropixels_UG3_Passive::writeConfiguration()
+{
+	errorCode = Neuropixels::writeProbeConfiguration(basestation->slot, headstage->port, dock, false);
+    if (errorCode == Neuropixels::SUCCESS)
+    {
+        LOGD("Succesfully wrote probe configuration");
+    }
+    else
+    {
+        LOGD("!!! FAILED TO WRITE PROBE CONFIGURATION !!! Slot: ", basestation->slot, " port: ", headstage->port, " error code: ", errorCode);
+    }
+}
+
+void Neuropixels_UG3_Passive::startAcquisition()
+{
+	ap_timestamp = 0;
+	lfp_timestamp = 0;
+
+	apBuffer->clear();
+	lfpBuffer->clear();
+
+	apView->reset();
+	lfpView->reset();
+
+	last_npx_timestamp = 0;
+	passedOneSecond = false;
+
+	SKIP = sendSync ? 385 : 384;
+
+	LOGD("  Starting thread.");
+	startThread();
+}
+
+void Neuropixels_UG3_Passive::stopAcquisition()
+{
+	LOGC("Probe stopping thread.");
+	signalThreadShouldExit();
+}
+
+void Neuropixels_UG3_Passive::run()
+{
+
+	while (!threadShouldExit())
+	{
+
+		int count = SAMPLECOUNT;
+
+		errorCode = Neuropixels::readElectrodeData(
+			basestation->slot,
+			headstage->port,
+			dock,
+			&packet[0],
+			&count,
+			count);
+
+		if (errorCode == Neuropixels::SUCCESS &&
+			count > 0)
+		{
+
+			for (int packetNum = 0; packetNum < count; packetNum++)
+			{
+				for (int i = 0; i < 12; i++)
+				{
+					eventCode = packet[packetNum].Status[i] >> 6; // AUX_IO<0:13>
+
+					uint32_t npx_timestamp = packet[packetNum].timestamp[i];
+
+					uint32_t timestamp_jump = npx_timestamp - last_npx_timestamp;
+
+					if (timestamp_jump > MAX_ALLOWABLE_TIMESTAMP_JUMP)
+					{
+						if (passedOneSecond && timestamp_jump < MAX_HEADSTAGE_CLK_SAMPLE)
+						{
+							LOGD("NPX TIMESTAMP JUMP: ", npx_timestamp - last_npx_timestamp,
+								", expected 3 or 4...Possible data loss on slot ",
+								int(basestation->slot_c), ", probe ", int(headstage->port_c),
+								" at sample number ", ap_timestamp);
+						}
+					}
+
+					last_npx_timestamp = npx_timestamp;
+
+					for (int j = 0; j < 384; j++)
+					{
+
+						apSamples[j + i * SKIP + packetNum * 12 * SKIP] =
+							float(packet[packetNum].apData[i][j]) * 1.2f / 1024.0f * 1000000.0f
+							/ settings.availableApGains[settings.apGainIndex]
+							- ap_offsets[j][0]; // convert to microvolts
+
+						apView->addSample(apSamples[j + i * SKIP + packetNum * 12 * SKIP], j);
+
+						if (i == 0)
+						{
+							lfpSamples[j + packetNum * SKIP] =
+								float(packet[packetNum].lfpData[j]) * 1.2f / 1024.0f * 1000000.0f
+								/ settings.availableLfpGains[settings.lfpGainIndex]
+								- lfp_offsets[j][0]; // convert to microvolts
+
+							lfpView->addSample(lfpSamples[j + packetNum * SKIP], j);
+						}
+					}
+
+					ap_timestamps[i + packetNum * 12] = ap_timestamp++;
+					event_codes[i + packetNum * 12] = eventCode;
+
+					if (sendSync)
+						apSamples[384 + i * SKIP + packetNum * 12 * SKIP] = (float)eventCode;
+
+				}
+
+				lfp_timestamps[packetNum] = lfp_timestamp++;
+				lfp_event_codes[packetNum] = eventCode;
+
+				if (sendSync)
+					lfpSamples[384 + packetNum * SKIP] = (float)eventCode;
+
+			}
+
+			apBuffer->addToBuffer(apSamples, ap_timestamps, timestamp_s, event_codes, 12 * count);
+			lfpBuffer->addToBuffer(lfpSamples, lfp_timestamps, timestamp_s, lfp_event_codes, count);
+
+			if (ap_offsets[0][0] == 0)
+			{
+				updateOffsets(apSamples, ap_timestamp, true);
+				updateOffsets(lfpSamples, lfp_timestamp, false);
+			}
+		}
+		else if (errorCode != Neuropixels::SUCCESS)
+		{
+			LOGD("readPackets error code: ", errorCode, " for Basestation ", int(basestation->slot), ", probe ", int(headstage->port));
+		}
+
+		if (ap_timestamp % 30000 == 0)
+			passedOneSecond = true;
+
+		int packetsAvailable;
+		int headroom;
+
+		Neuropixels::getElectrodeDataFifoState(
+			basestation->slot,
+			headstage->port,
+			dock,
+			&packetsAvailable,
+			&headroom);
+
+		fifoFillPercentage = float(packetsAvailable) / float(packetsAvailable + headroom);
+
+		if (packetsAvailable < MAXPACKETS)
+		{
+			int uSecToWait = (MAXPACKETS - packetsAvailable) * 400;
+
+			std::this_thread::sleep_for(std::chrono::microseconds(uSecToWait));
+		}
+	}
+
+}
+
+bool Neuropixels_UG3_Passive::runBist(BIST bistType)
+{
+
+	close();
+	open();
+
+	int slot = basestation->slot;
+	int port = headstage->port;
+
+	bool returnValue = false;
+
+	switch (bistType)
+	{
+	case BIST::SIGNAL:
+	{
+		if (Neuropixels::bistSignal(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::NOISE:
+	{
+		if (Neuropixels::bistNoise(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::PSB:
+	{
+		if (Neuropixels::bistPSB(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::SR:
+	{
+		if (Neuropixels::bistSR(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::EEPROM:
+	{
+		if (Neuropixels::bistEEPROM(slot, port) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::I2C:
+	{
+		if (Neuropixels::bistI2CMM(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	}
+	case BIST::SERDES:
+	{
+		int errors;
+		Neuropixels::bistStartPRBS(slot, port);
+		Sleep(200);
+		Neuropixels::bistStopPRBS(slot, port, &errors);
+
+		if (errors == 0)
+			returnValue = true;
+		break;
+	}
+	case BIST::HB:
+	{
+		if (Neuropixels::bistHB(slot, port, dock) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	} case BIST::BS:
+	{
+		if (Neuropixels::bistBS(slot) == Neuropixels::SUCCESS)
+			returnValue = true;
+		break;
+	} default:
+		CoreServices::sendStatusMessage("Test not found.");
+	}
+
+	close();
+	open();
+	initialize(false);
+
+	errorCode = Neuropixels::setSWTrigger(slot);
+	errorCode = Neuropixels::arm(slot);
+
+	return returnValue;
+}

--- a/Source/Probes/Neuropixels_UG3_Passive.h
+++ b/Source/Probes/Neuropixels_UG3_Passive.h
@@ -1,0 +1,114 @@
+/*
+------------------------------------------------------------------
+
+This file is part of the Open Ephys GUI
+Copyright (C) 2020 Allen Institute for Brain Science and Open Ephys
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef __NEUROPIXUG3_PASSIVE_H_2C4C2D67__
+#define __NEUROPIXUG3_PASSIVE_H_2C4C2D67__
+
+#include "../NeuropixComponents.h"
+
+#include "../API/v3/NeuropixAPI.h"
+
+#define MAXPACKETS 64
+
+/**
+
+	Acquires data from a 384-channel IMEC headstage, connected to a subset of
+    UG3 grid or depth probe channels. Multiple instances of this Neuropixels_UG3_Passive probe
+    (i.e. multiple IMEC headstages) correspond to a single 1024-+ channel UG3 grid.
+*/
+
+class Neuropixels_UG3_Passive : public Probe
+{
+public:
+
+	/** Constructor */
+	Neuropixels_UG3_Passive(Basestation* bs, Headstage* hs, Flex* fl, uint64_t serialNumber);
+
+	/** Reads probe part number and serial number */
+	void getInfo() override;
+
+	/** Opens the connection to the probe (fast) */
+	bool open() override;
+
+	/** Closes the connection to the probe (fast) */
+	bool close() override;
+
+	/** Call init, setOPMODE, and setHSLED (slow) */
+	void initialize(bool signalChainIsLoading) override;
+
+	/** Selects active electrodes based on settings.selectedChannel */
+	void selectElectrodes() override;
+
+	/** Sets reference for all channels based on settings.referenceIndex */
+	void setAllReferences() override;
+
+	/** Sets gains for all channels based on settings.apGainIndex and settings.lfpGainIndex */
+	void setAllGains() override;
+
+	/** Sets AP filter cut based on settings.apFilterState */
+	void setApFilterState() override;
+	
+	/** Writes latest settings to the probe (slow) */
+	void writeConfiguration() override;
+
+	/** Resets timestamps, clears buffers, and starts the thread*/
+	void startAcquisition() override;
+
+	/** Stops the thread */
+	void stopAcquisition() override;
+
+	/** Runs a built-in self test. */
+	bool runBist(BIST bistType) override;
+
+	/** Uploads ADC and gain calibration files */
+	void calibrate() override;
+
+	/** Signals that this probe has an LFP data stream*/
+	bool generatesLfpData() { return true; }
+
+	/** Signals that this probe has an AP filter switch*/
+	bool hasApFilterSwitch() { return true; }
+
+	/** Acquires data from the probe */
+	void run() override; // acquire data
+
+private:
+
+	Neuropixels::electrodePacket packet[SAMPLECOUNT];
+	Neuropixels::NP_ErrorCode errorCode;
+
+	Array<int> channel_map;
+
+	int SKIP;
+
+	float apSamples[385 * 12 * MAXPACKETS];
+	float lfpSamples[385 * MAXPACKETS];
+	int64 ap_timestamps[12 * MAXPACKETS];
+	uint64 event_codes[12 * MAXPACKETS];
+	int64 lfp_timestamps[MAXPACKETS];
+	uint64 lfp_event_codes[MAXPACKETS];
+
+};
+
+
+#endif  // _NEUROPIXNHP_PASSIVE_2C4C2D67__

--- a/Source/UI/NeuropixInterface.cpp
+++ b/Source/UI/NeuropixInterface.cpp
@@ -1612,6 +1612,9 @@ void NeuropixInterface::loadParameters(XmlElement* xml)
                     else if (PN.equalsIgnoreCase("NP1200") || PN.equalsIgnoreCase("NP1210"))
                         type = ProbeType::NHP1;
 
+                    else if (PN.equalsIgnoreCase("UG3100"))
+                        type = ProbeType::UG3;
+
                     else if (PN.equalsIgnoreCase("PRB2_1_2_0640_0") || PN.equalsIgnoreCase("NP2000"))
                         type = ProbeType::NP2_1;
 


### PR DESCRIPTION
Adding a new probe type, the UG3 probe, in order to support our use of the IMEC 384-ch passive headstages with our UG3 grids.